### PR TITLE
Add ingester.wal.dir to enable the Loki container to start (See issue #15)

### DIFF
--- a/cfg-template/loki-docker-local-config.yaml
+++ b/cfg-template/loki-docker-local-config.yaml
@@ -22,6 +22,8 @@ ingester:
   chunk_target_size: 1048576  # Try to build bigger chunks if there is sufficient data, although for logging shell commands we will never hit this.
   chunk_retain_period: 30s
   max_transfer_retries: 0
+  wal:
+    dir: /loki/.cache/loki/wal
 
 schema_config:
   configs:


### PR DESCRIPTION
This adds configuration to the ingester service in the supplied loki docker config file.
Lack of a writeable wal directory causes the existing default configuration to fail.